### PR TITLE
Throw a specific exception when the request is api rate limited.

### DIFF
--- a/Exception/ApiRateExceededException.php
+++ b/Exception/ApiRateExceededException.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of the Swiftype App Search PHP Client package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Swiftype\AppSearch\Exception;
+
+use Swiftype\Exception\ApiException;
+use Swiftype\Exception\SwiftypeException;
+
+/**
+ * Exception thrown when the API Rate limit have been exceded.
+ *
+ * @package Swiftype\Exception
+ *
+ * @author  Aurélien FOUCRET <aurelien.foucret@elastic.co>
+ */
+class ApiRateExceededException extends ApiException implements SwiftypeException
+{
+    /**
+     * @var int
+     */
+    private $limit;
+
+    /**
+     * @var int
+     */
+    private $retryAfter;
+
+    /**
+     * Exception constructor.
+     *
+     * @param mixed $message
+     * @param int   $limit
+     * @param int   $retryAfter
+     * @param mixed $code
+     * @param mixed $previous
+     */
+    public function __construct($message = null, $limit = null, $retryAfter = null, $code = null, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->limit = $limit;
+        $this->retryAfter = $retryAfter;
+    }
+
+    /**
+     * Return the max number of call allowed over a period.
+     *
+     * @return string
+     */
+    public function getApiRateLimit()
+    {
+        return $this->limit;
+    }
+
+    /**
+     * Indicate the ttl before trying again to use the API.
+     *
+     * @return string
+     */
+    public function getRetryAfter()
+    {
+        return $this->retryAfter;
+    }
+}

--- a/Tests/Unit/Connection/Handler/ApiErrorHandlerTest.php
+++ b/Tests/Unit/Connection/Handler/ApiErrorHandlerTest.php
@@ -11,6 +11,7 @@ namespace Swiftype\AppSearch\Tests\Unit\Connection\Handler;
 use GuzzleHttp\Ring\Future\CompletedFutureArray;
 use PHPUnit\Framework\TestCase;
 use Swiftype\AppSearch\Connection\Handler\ApiErrorHandler;
+use Swiftype\AppSearch\Connection\Handler\RateLimitLoggingHandler;
 
 /**
  * Check API errors are turns into comprehensive exceptions by the handler.
@@ -43,6 +44,32 @@ class ApiErrorHandlerTest extends TestCase
 
         if (null == $exceptionClass) {
             $this->assertEquals($response, $handlerResponse);
+        }
+    }
+
+    /**
+     * Test if the ApiRateExceededException excecption contains valid limit and retry values.
+     *
+     * @param int $limit
+     * @param int $retryAfter
+     */
+    public function testApiRateLimited($limit = 10, $retryAfter = 20)
+    {
+        $headers = [
+            RateLimitLoggingHandler::RATE_LIMIT_LIMIT_HEADER_NAME => [$limit],
+            RateLimitLoggingHandler::RETRY_AFTER_HEADER_NAME => [$retryAfter],
+        ];
+        $handler = new ApiErrorHandler(
+            function ($request) use ($headers) {
+                return new CompletedFutureArray(['status' => 429, 'headers' => $headers]);
+            }
+        );
+
+        try {
+            $handler([])->wait();
+        } catch (\Swiftype\AppSearch\Exception\ApiRateExceededException $e) {
+            $this->assertEquals($limit, $e->getApiRateLimit());
+            $this->assertEquals($retryAfter, $e->getRetryAfter());
         }
     }
 

--- a/Tests/Unit/Connection/Handler/RateLimitLoggingHandlerTest.php
+++ b/Tests/Unit/Connection/Handler/RateLimitLoggingHandlerTest.php
@@ -34,7 +34,7 @@ class RateLimitLoggingHandlerTest extends TestCase
     public function testExceptionTypes($limit, $remaining)
     {
         $response = ['headers' => array_filter($this->getResponseHeaders($limit, $remaining))];
-        $handler  = $this->getHandler($response);
+        $handler = $this->getHandler($response);
 
         $handler([])->wait();
 
@@ -65,10 +65,10 @@ class RateLimitLoggingHandlerTest extends TestCase
     /**
      * Indicate if a warning should be logged or not.
      *
-     * @param integer|NULL $limit
-     * @param integer|NULL $remaining
+     * @param int|null $limit
+     * @param int|null $remaining
      *
-     * @return boolean
+     * @return bool
      */
     private function shouldLogWarning($limit, $remaining)
     {
@@ -78,16 +78,16 @@ class RateLimitLoggingHandlerTest extends TestCase
     /**
      * Return response headers.
      *
-     * @param integer|NULL $limit
-     * @param integer|NULL $remaining
+     * @param int|null $limit
+     * @param int|null $remaining
      *
      * @return array[]
      */
     private function getResponseHeaders($limit, $remaining)
     {
         return [
-            RateLimitLoggingHandler::RATE_LIMIT_LIMIT_HEADER_NAME => $limit,
-            RateLimitLoggingHandler::RATE_LIMIT_REMAINING_HEADER_NAME => $remaining,
+            RateLimitLoggingHandler::RATE_LIMIT_LIMIT_HEADER_NAME => [$limit],
+            RateLimitLoggingHandler::RATE_LIMIT_REMAINING_HEADER_NAME => [$remaining],
         ];
     }
 

--- a/Tests/Unit/Connection/Handler/_data/apiError.yml
+++ b/Tests/Unit/Connection/Handler/_data/apiError.yml
@@ -77,6 +77,13 @@
   - Error msg.
 
 -
+  - status: 429
+    body:
+      error: Error msg.
+  - \Swiftype\AppSearch\Exception\ApiRateExceededException
+  - Error msg.
+
+-
   - status: 500
     body:
       error: Error msg.


### PR DESCRIPTION
I propose to throw a specific exception when the api is rate limited.

The previous behavior was to raise an ApiException (kind of generic behavior if the HTTP status code is 4xx). Now we have an ApiRateExceededException. Developer can avoid to parse the error message and rely on the exception type.

Additionally, when catching this exception developers can access to:

API limit : $e->getApiRateLimit()
Retry after : $e->getRettyAfter()
This values are read from the response headers and should allow to implement custom retry policies.